### PR TITLE
Allow setting tags at the class level

### DIFF
--- a/akka/src/main/scala/net/gfxmonk/backpressure/akka/BackpressureAkka.scala
+++ b/akka/src/main/scala/net/gfxmonk/backpressure/akka/BackpressureAkka.scala
@@ -56,7 +56,7 @@ class BackpressureSensor private(statsClient: StatsDClient, sampleRate: Double, 
       sampleRate = sampleRate
     )
     val clockImpl = new internal.Clock {
-      override def microsMonotonic(): Long = System.nanoTime() * 1000000L
+      override def microsMonotonic(): Long = System.nanoTime() / 1000L
     }
     BackpressureSensor.flow[T](clockImpl, stats)
   }

--- a/akka/src/main/scala/net/gfxmonk/backpressure/akka/BackpressureAkka.scala
+++ b/akka/src/main/scala/net/gfxmonk/backpressure/akka/BackpressureAkka.scala
@@ -11,8 +11,8 @@ import net.gfxmonk.backpressure.internal.statsd.StatsdImpl
 import java.util.concurrent.atomic.AtomicLong
 
 object BackpressureSensor {
-  def apply(statsDClient: StatsDClient, sampleRate: Double = 1.0): BackpressureSensor = {
-    new BackpressureSensor(statsDClient, sampleRate)
+  def apply(statsDClient: StatsDClient, sampleRate: Double = 1.0, baseTags: Map[String, String] = Map.empty): BackpressureSensor = {
+    new BackpressureSensor(statsDClient, sampleRate, baseTags)
   }
 
   private [backpressure] def flow[T](clock: Clock, stats: StatsClient) : Graph[FlowShape[T, T], NotUsed] = {
@@ -48,11 +48,11 @@ object BackpressureSensor {
   }
 }
 
-class BackpressureSensor private(statsClient: StatsDClient, sampleRate: Double) {
+class BackpressureSensor private(statsClient: StatsDClient, sampleRate: Double, baseTags: Map[String, String]) {
   def flow[T](metricPrefix: String, tags: Map[String, String] = Map.empty) : Graph[FlowShape[T, T], NotUsed] = {
     val stats = new StatsdImpl(statsClient,
       metricPrefix = metricPrefix,
-      tags = tags,
+      tags = baseTags ++ tags,
       sampleRate = sampleRate
     )
     val clockImpl = new internal.Clock {

--- a/monix/src/main/scala/net/gfxmonk/backpressure/monix/BackpressureMonix.scala
+++ b/monix/src/main/scala/net/gfxmonk/backpressure/monix/BackpressureMonix.scala
@@ -12,8 +12,8 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.Future
 
 object BackpressureSensor {
-  def apply(statsDClient: StatsDClient, sampleRate: Double = 1.0): BackpressureSensor = {
-    new BackpressureSensor(statsDClient, sampleRate)
+  def apply(statsDClient: StatsDClient, sampleRate: Double = 1.0, baseTags: Map[String, String] = Map.empty): BackpressureSensor = {
+    new BackpressureSensor(statsDClient, sampleRate, baseTags)
   }
 
   private [backpressure] def operator[T](stats: StatsClient) : Operator[T,T] = {
@@ -43,12 +43,12 @@ object BackpressureSensor {
   }
 }
 
-class BackpressureSensor private(statsClient: StatsDClient, sampleRate: Double) {
+class BackpressureSensor private(statsClient: StatsDClient, sampleRate: Double, baseTags: Map[String, String]) {
 
   def operator[T](metricPrefix: String, tags: Map[String,String] = Map.empty) : Operator[T,T] = {
     val stats = new StatsdImpl(statsClient,
       metricPrefix = metricPrefix,
-      tags = tags,
+      tags = baseTags ++ tags,
       sampleRate = sampleRate
     )
     BackpressureSensor.operator(stats)


### PR DESCRIPTION
It's useful to be able to set tags once and have them applied for every flow implementation.

Also fixed the microsecond calculation.