### PR TITLE
Decouple stats client

### DIFF
--- a/akka/src/main/scala/net/gfxmonk/backpressure/akka/BackpressureAkka.scala
+++ b/akka/src/main/scala/net/gfxmonk/backpressure/akka/BackpressureAkka.scala
@@ -5,8 +5,9 @@ import _root_.akka.stream.{Attributes, FlowShape, Graph, Inlet, Outlet}
 import akka.NotUsed
 import com.timgroup.statsd.StatsDClient
 import net.gfxmonk.backpressure.internal
-import net.gfxmonk.backpressure.internal.{Clock, Logic, StatsClient, StatsClientBuilder}
+import net.gfxmonk.backpressure.internal.{Clock, Logic}
 import net.gfxmonk.backpressure.internal.statsd.StatsdImpl
+import net.gfxmonk.backpressure.stats.{StatsClient, StatsClientBuilder}
 
 import java.util.concurrent.atomic.AtomicLong
 

--- a/akka/src/main/scala/net/gfxmonk/backpressure/akka/BackpressureAkka.scala
+++ b/akka/src/main/scala/net/gfxmonk/backpressure/akka/BackpressureAkka.scala
@@ -5,14 +5,18 @@ import _root_.akka.stream.{Attributes, FlowShape, Graph, Inlet, Outlet}
 import akka.NotUsed
 import com.timgroup.statsd.StatsDClient
 import net.gfxmonk.backpressure.internal
-import net.gfxmonk.backpressure.internal.{Clock, Logic, StatsClient}
+import net.gfxmonk.backpressure.internal.{Clock, Logic, StatsClient, StatsClientBuilder}
 import net.gfxmonk.backpressure.internal.statsd.StatsdImpl
 
 import java.util.concurrent.atomic.AtomicLong
 
 object BackpressureSensor {
-  def apply(statsDClient: StatsDClient, sampleRate: Double = 1.0, baseTags: Map[String, String] = Map.empty): BackpressureSensor = {
-    new BackpressureSensor(statsDClient, sampleRate, baseTags)
+  def apply(statsClientBuilder: StatsClientBuilder, sampleRate: Double = 1.0, baseTags: Map[String, String] = Map.empty): BackpressureSensor = {
+    new BackpressureSensor(statsClientBuilder, sampleRate, baseTags)
+  }
+
+  def statsD(statsDClient: StatsDClient, sampleRate: Double = 1.0, baseTags: Map[String, String] = Map.empty): BackpressureSensor = {
+    BackpressureSensor(StatsdImpl.builder(statsDClient), sampleRate, baseTags)
   }
 
   private [backpressure] def flow[T](clock: Clock, stats: StatsClient) : Graph[FlowShape[T, T], NotUsed] = {
@@ -48,16 +52,11 @@ object BackpressureSensor {
   }
 }
 
-class BackpressureSensor private(statsClient: StatsDClient, sampleRate: Double, baseTags: Map[String, String]) {
+class BackpressureSensor private(statsClientBuilder: StatsClientBuilder, sampleRate: Double, baseTags: Map[String, String]) {
   def flow[T](metricPrefix: String, tags: Map[String, String] = Map.empty) : Graph[FlowShape[T, T], NotUsed] = {
-    val stats = new StatsdImpl(statsClient,
-      metricPrefix = metricPrefix,
-      tags = baseTags ++ tags,
-      sampleRate = sampleRate
-    )
     val clockImpl = new internal.Clock {
       override def microsMonotonic(): Long = System.nanoTime() / 1000L
     }
-    BackpressureSensor.flow[T](clockImpl, stats)
+    BackpressureSensor.flow[T](clockImpl, statsClientBuilder.build(metricPrefix, sampleRate, baseTags ++ tags))
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ lazy val monix = (project in file("monix")).settings(
   publicProjectSettings,
   name := "backpressure-sensor-monix",
   libraryDependencies ++= monixDeps,
-).dependsOn(core, statsd)
+).dependsOn(core % "compile->compile;test->test", statsd)
 
 lazy val akka = (project in file("akka")).settings(
   commonSettings,

--- a/core/src/main/scala/net/gfxmonk/backpressure/internal/Logic.scala
+++ b/core/src/main/scala/net/gfxmonk/backpressure/internal/Logic.scala
@@ -2,27 +2,31 @@ package net.gfxmonk.backpressure.internal
 
 import java.util.concurrent.atomic.AtomicLong
 
-private [backpressure] trait Clock {
-  def microsMonotonic(): Long
+trait StatsClient {
+  def measure(metric: IntegerMetric, cause: Cause, value: Long): Unit
+  def measure(metric: FloatMetric, cause: Cause, value: Double): Unit
 }
 
-private [backpressure] sealed trait Cause
-private [backpressure] object Cause {
+trait StatsClientBuilder {
+  def build(metricPrefix: String, sampleRate: Double, baseTags: Map[String, String]): StatsClient
+}
+
+sealed trait Cause
+object Cause {
   case object Waiting extends Cause
   case object Busy extends Cause
 }
 
-private [backpressure] sealed trait IntegerMetric
-private [backpressure] sealed trait FloatMetric
-private [backpressure] object Metric {
+sealed trait IntegerMetric
+sealed trait FloatMetric
+object Metric {
   case object Duration extends IntegerMetric
   case object Variance extends IntegerMetric
   case object Load extends FloatMetric
 }
 
-private [backpressure] trait StatsClient {
-  def measure(metric: IntegerMetric, cause: Cause, value: Long): Unit
-  def measure(metric: FloatMetric, cause: Cause, value: Double): Unit
+private [backpressure] trait Clock {
+  def microsMonotonic(): Long
 }
 
 private [backpressure] class Logic(clock: Clock, stats: StatsClient) {

--- a/core/src/main/scala/net/gfxmonk/backpressure/internal/Logic.scala
+++ b/core/src/main/scala/net/gfxmonk/backpressure/internal/Logic.scala
@@ -1,15 +1,8 @@
 package net.gfxmonk.backpressure.internal
 
+import net.gfxmonk.backpressure.stats.StatsClient
+
 import java.util.concurrent.atomic.AtomicLong
-
-trait StatsClient {
-  def measure(metric: IntegerMetric, cause: Cause, value: Long): Unit
-  def measure(metric: FloatMetric, cause: Cause, value: Double): Unit
-}
-
-trait StatsClientBuilder {
-  def build(metricPrefix: String, sampleRate: Double, baseTags: Map[String, String]): StatsClient
-}
 
 sealed trait Cause
 object Cause {

--- a/core/src/main/scala/net/gfxmonk/backpressure/stats/StatsClient.scala
+++ b/core/src/main/scala/net/gfxmonk/backpressure/stats/StatsClient.scala
@@ -1,0 +1,12 @@
+package net.gfxmonk.backpressure.stats
+
+import net.gfxmonk.backpressure.internal.{Cause, FloatMetric, IntegerMetric}
+
+trait StatsClient {
+  def measure(metric: IntegerMetric, cause: Cause, value: Long): Unit
+  def measure(metric: FloatMetric, cause: Cause, value: Double): Unit
+}
+
+trait StatsClientBuilder {
+  def build(metricPrefix: String, sampleRate: Double, baseTags: Map[String, String]): StatsClient
+}

--- a/core/src/test/scala/net/gfxmonk/backpressure/stats/TestStatsClient.scala
+++ b/core/src/test/scala/net/gfxmonk/backpressure/stats/TestStatsClient.scala
@@ -1,0 +1,28 @@
+package net.gfxmonk.backpressure.stats
+
+import net.gfxmonk.backpressure.internal.{Cause, FloatMetric, IntegerMetric}
+
+import scala.collection.mutable.ListBuffer
+
+class TestStatsClient extends StatsClient {
+  private val ints_ = ListBuffer[(IntegerMetric, Cause, Long)]()
+
+  def ints = ints_.toList
+
+  private val floats_ = ListBuffer[(FloatMetric, Cause, Double)]()
+
+  def floats = floats_.toList
+
+  override def measure(metric: IntegerMetric, cause: Cause, value: Long): Unit = {
+    ints_.append((metric, cause, value))
+  }
+
+  override def measure(metric: FloatMetric, cause: Cause, value: Double): Unit = {
+    floats_.append((metric, cause, value))
+  }
+}
+
+object TestStatsClient {
+  val builder: StatsClientBuilder =
+    (_, _, _) => new TestStatsClient()
+}

--- a/example/src/main/scala/net/gfxmonk/backpressure/example/BackpressureSensorTestMain.scala
+++ b/example/src/main/scala/net/gfxmonk/backpressure/example/BackpressureSensorTestMain.scala
@@ -44,7 +44,7 @@ object BackpressureSensorTestMain extends TaskApp {
     for {
       _ <- Task(println(s"start: ${name}"))
       statsd <- buildStatsd
-      sensor = BackpressureSensor(statsd)
+      sensor = BackpressureSensor.statsD(statsd)
       _ <- Observable.repeat(())
         .delayOnNext(upstreamInterval)
         .mapEval(delayUpto(upstreamVariance))

--- a/monix/src/main/scala/net/gfxmonk/backpressure/monix/BackpressureMonix.scala
+++ b/monix/src/main/scala/net/gfxmonk/backpressure/monix/BackpressureMonix.scala
@@ -5,8 +5,9 @@ import _root_.monix.execution.{Ack, Scheduler}
 import _root_.monix.reactive.Observable.Operator
 import _root_.monix.reactive.observers.Subscriber
 import com.timgroup.statsd.StatsDClient
-import net.gfxmonk.backpressure.internal.{Clock, Logic, StatsClient, StatsClientBuilder}
+import net.gfxmonk.backpressure.internal.{Clock, Logic}
 import net.gfxmonk.backpressure.internal.statsd.StatsdImpl
+import net.gfxmonk.backpressure.stats.{StatsClient, StatsClientBuilder}
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.Future

--- a/monix/src/test/scala/net/gfxmonk/backpressure/monix/MonixBackpressureSensorSpec.scala
+++ b/monix/src/test/scala/net/gfxmonk/backpressure/monix/MonixBackpressureSensorSpec.scala
@@ -6,35 +6,17 @@ import monix.reactive.Observable
 import net.gfxmonk.backpressure.internal.Cause.{Busy, Waiting}
 import net.gfxmonk.backpressure.internal.Metric.{Duration, Load, Variance}
 import net.gfxmonk.backpressure.internal._
+import net.gfxmonk.backpressure.stats.TestStatsClient
 import weaver.monixcompat.SimpleTaskSuite
 
 import java.util.concurrent.TimeUnit
-import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration.DurationInt
 import scala.util.Success
 
 object MonixBackpressureSensorSpec extends SimpleTaskSuite {
-  private [backpressure] class TestStats extends StatsClient {
-    private val ints_ = ListBuffer[(IntegerMetric, Cause, Long)]()
-
-    def ints = ints_.toList
-
-    private val floats_ = ListBuffer[(FloatMetric, Cause, Double)]()
-
-    def floats = floats_.toList
-
-    override def measure(metric: IntegerMetric, cause: Cause, value: Long): Unit = {
-      ints_.append((metric, cause, value))
-    }
-
-    override def measure(metric: FloatMetric, cause: Cause, value: Double): Unit = {
-      floats_.append((metric, cause, value))
-    }
-  }
-
   class Ctx() {
     val scheduler = TestScheduler()
-    val stats = new TestStats()
+    val stats = new TestStatsClient()
     val clock: Clock = new Clock {
       override def microsMonotonic(): Long = scheduler.clockMonotonic(TimeUnit.MICROSECONDS)
     }

--- a/statsd/src/main/scala/net/gfxmonk/backpressure/internal/statsd/StatsdImpl.scala
+++ b/statsd/src/main/scala/net/gfxmonk/backpressure/internal/statsd/StatsdImpl.scala
@@ -1,7 +1,8 @@
 package net.gfxmonk.backpressure.internal.statsd
 
 import com.timgroup.statsd.StatsDClient
-import net.gfxmonk.backpressure.internal.{Cause, FloatMetric, IntegerMetric, Metric, StatsClient, StatsClientBuilder}
+import net.gfxmonk.backpressure.internal.{Cause, FloatMetric, IntegerMetric, Metric}
+import net.gfxmonk.backpressure.stats.{StatsClient, StatsClientBuilder}
 
 private [backpressure] class StatsdImpl(client: StatsDClient, metricPrefix: String, tags: Map[String, String], sampleRate: Double) extends StatsClient {
   private val histogramMetric = metricPrefix + ".micros"
@@ -36,13 +37,12 @@ private [backpressure] class StatsdImpl(client: StatsDClient, metricPrefix: Stri
 }
 
 private [backpressure] object StatsdImpl {
-  def builder(statsDClient: StatsDClient): StatsClientBuilder = {
-    case (metricPrefix: String, sampleRate: Double, tags: Map[String, String]) =>
+  def builder(statsDClient: StatsDClient): StatsClientBuilder =
+    (metricPrefix: String, sampleRate: Double, tags: Map[String, String]) =>
     new StatsdImpl(
       statsDClient,
       metricPrefix,
       tags,
       sampleRate
     )
-  }
 }

--- a/statsd/src/main/scala/net/gfxmonk/backpressure/internal/statsd/StatsdImpl.scala
+++ b/statsd/src/main/scala/net/gfxmonk/backpressure/internal/statsd/StatsdImpl.scala
@@ -1,7 +1,7 @@
 package net.gfxmonk.backpressure.internal.statsd
 
 import com.timgroup.statsd.StatsDClient
-import net.gfxmonk.backpressure.internal.{Cause, FloatMetric, IntegerMetric, Metric, StatsClient}
+import net.gfxmonk.backpressure.internal.{Cause, FloatMetric, IntegerMetric, Metric, StatsClient, StatsClientBuilder}
 
 private [backpressure] class StatsdImpl(client: StatsDClient, metricPrefix: String, tags: Map[String, String], sampleRate: Double) extends StatsClient {
   private val histogramMetric = metricPrefix + ".micros"
@@ -36,5 +36,13 @@ private [backpressure] class StatsdImpl(client: StatsDClient, metricPrefix: Stri
 }
 
 private [backpressure] object StatsdImpl {
-  type Builder = (String, Map[String,String]) => StatsdImpl
+  def builder(statsDClient: StatsDClient): StatsClientBuilder = {
+    case (metricPrefix: String, sampleRate: Double, tags: Map[String, String]) =>
+    new StatsdImpl(
+      statsDClient,
+      metricPrefix,
+      tags,
+      sampleRate
+    )
+  }
 }


### PR DESCRIPTION
Replaced the statsDClient in the backpressure class with a statsClientBuilder so that the implementations are not tied to statsD.